### PR TITLE
Use the nsist Python API to build the installer

### DIFF
--- a/make_windows_installer.py
+++ b/make_windows_installer.py
@@ -3,12 +3,11 @@ import os
 import sys
 import shutil
 import glob
-import datetime
-import subprocess
-import configparser
 
 import latus.const
 import latus.util
+
+import nsist
 
 installer_string = 'installer'
 config_path = 'installer.cfg'
@@ -31,18 +30,22 @@ for existing_installer in existing_installers:
     print('removing %s' % existing_installer)
     os.remove(existing_installer)
 
-config = configparser.ConfigParser()
-config['Application'] = {'name': latus.const.NAME,
-                         'version': version,
-                         # 'icon': os.path.join('icons', 'latus.ico'),
-                         # 'console': 'True',
-                         'entry_point': 'latus_main:main'}
+kwargs = {'appname': latus.const.NAME,
+          'version': version,
+          'shortcuts': {
+              latus.const.NAME: {'entry_point': 'latus_main:main',
+                                 # 'console': 'True',
+                                 # 'icon': os.path.join('icons', 'latus.ico'),
+                                },
+          },
+          # 'icon': os.path.join('icons', 'latus.ico'),
 
-# use this Python's version for the build version
-config['Python'] = {'version': sys.version.split()[0]}
+          # use this Python's version for the build version
+          'py_version': sys.version.split()[0],
+         }
 
 # make the requirements list out of requirements.txt
-requirements = []
+kwargs['packages'] = requirements = []
 with open('requirements.txt') as f:
     for l in f:
         l = l.strip()
@@ -50,24 +53,10 @@ with open('requirements.txt') as f:
             requirements.append(l)
 requirements.append(latus.const.NAME)  # we need to include ourselves too
 requirements.append('icons')  # and the icons code
-requirements_string = None
-for requirement in requirements:
-    if len(requirement) > 0:
-        if requirements_string is None:
-            requirements_string = requirement
-        else:
-            requirements_string += '\n' + requirement
-config['Include'] = {'packages': requirements_string}
 
-if True:
-    # write out the config
-    with open(config_path, 'w') as configfile:
-        config.write(configfile, space_around_delimiters=False)
-        configfile.write('files = LICENSE\n')
-        configfile.write(' README.md')
-
-# finally execute nsist to create the installer
-subprocess.call([sys.executable, '-m', 'nsist', config_path])
+# Call pynsist to build the installer
+ib = nsist.InstallerBuilder(**kwargs)
+ib.run()
 
 # copy the installer over to the dist folder
 installer_path = latus.const.NAME + '_' + version + '.exe'


### PR DESCRIPTION
This seems simpler than writing out a config file only to have it immediately read by another piece of Python code. I haven't tested this script, so it might need some adjustments, but it should be roughly correct.

The API is (roughly) documented here: http://pynsist.readthedocs.org/en/latest/api/main.html